### PR TITLE
fix sunburst example on remote servers

### DIFF
--- a/sunburst/import.js
+++ b/sunburst/import.js
@@ -21,7 +21,7 @@
 // be displayed, as they were not annotated.
 
 var rootId = 8;
-var apiPath = "/api/v2/";
+var apiPath = "http://api.brain-map.org/api/v2/";
 var ontologyId = 1; 
 var structureGraphId = 1; 
 


### PR DESCRIPTION
The sunburst example, specifically import.js, was designed to work specifically on the main brain map API website.

This change allows for any server to load data remotely into the sunburst visualization.
